### PR TITLE
Update upstream to 1.3.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,10 @@
 .{
     .name = "zlib",
-    .version = "1.3.1-3",
+    .version = "1.3.1-4",
     .dependencies = .{
         .zlib = .{
-            .url = "https://github.com/madler/zlib/archive/refs/tags/v1.3.tar.gz",
-            .hash = "12207d353609d95cee9da7891919e6d9582e97b7aa2831bd50f33bf523a582a08547",
+            .url = "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+            .hash = "1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb",
         },
     },
     .paths = .{


### PR DESCRIPTION
Bump upstream to 1.3.1, which also [fixes build on Darwin](https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9) with zig 0.13.