### PR TITLE
updating to zig 0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /zig-cache
 /zig-out
+/.zig-cache

--- a/build.zig
+++ b/build.zig
@@ -2,10 +2,13 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const upstream = b.dependency("zlib", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "z",
-        .target = b.standardTargetOptions(.{}),
-        .optimize = b.standardOptimizeOption(.{}),
+        .root_module = b.createModule(.{
+            .target = b.standardTargetOptions(.{}),
+            .optimize = b.standardOptimizeOption(.{}),
+        }),
+        .linkage = .static,
     });
     lib.linkLibC();
     lib.addCSourceFiles(.{
@@ -34,11 +37,9 @@ pub fn build(b: *std.Build) void {
             "-DZ_HAVE_UNISTD_H",
         },
     });
-    lib.installHeadersDirectory(upstream.path(""), "", .{
-        .include_extensions = &.{
-            "zconf.h",
-            "zlib.h",
-        },
-    });
+
+    lib.installHeader(upstream.path("zconf.h"), "zconf.h");
+    lib.installHeader(upstream.path("zlib.h"), "zlib.h");
+
     b.installArtifact(lib);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,14 @@
 .{
-    .name = "zlib",
-    .version = "1.3.1",
+    .name = .zlib,
+    .version = "1.3.1-4",
+    .fingerprint = 0x73887d3a2db5a5be, // Changing this has security and trust implications.
+
+    .minimum_zig_version = "0.14.0",
+
     .dependencies = .{
         .zlib = .{
             .url = "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
-            .hash = "1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb",
+            .hash = "N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o",
         },
     },
     .paths = .{


### PR DESCRIPTION
This updates build.zig and build.zig.zon to work with zig 0.14.0. I tested this against the cpython project and all seems to be running there. 

For version I bumped this to 1.3.1-4 since there are already tags for a 1-3 suffix. Let me know if something else is better here or if version should stay the same an you had something else in mind for making unique tags. 

There may also be a regression? The following code from the original:
```zig
    lib.installHeadersDirectory(upstream.path(""), "", .{
        .include_extensions = &.{
            "zconf.h",
            "zlib.h",
        },
    });
```
was giving me the following error:
```
install
└─ install z failure
error: unable to open source directory '': FileNotFound
Build Summary: 1/3 steps succeeded; 1 failed
install transitive failure
└─ install z failure
```
I substituted it with explicit install header calls which feels cleaner to me anyway, but figured I'd bring it up since the call to installHeadersDirectory looks like it should still work.
```zig
    lib.installHeader(upstream.path("zconf.h"), "zconf.h");
    lib.installHeader(upstream.path("zlib.h"), "zlib.h");
```
