### PR TITLE
add Deflate Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,32 @@ your_compilation.linkLibrary(zlib_dep.artifact("z"));
 ```
 
 This will provide zlib as a static library to `your_compilation`.
+
+or, use the Deflate writer module:
+
+```zig
+
+const zlib_dep = b.dependency("zlib", .{
+    .target = target,
+    .optimize = optimize,
+});
+your_compilation.root_module.addImport("zlib", zlib_dep.module("zlib"));
+```
+
+and in your code:
+
+```
+const Deflate = @import("zlib").Deflate;
+var compressor = try Deflate.init(.{
+    .allocator = your_allocator,
+    .writer = &output.interface,
+    .container = .gzip,
+});
+defer compressor.deinit();
+
+// ...
+// write to compressor.writer
+// ...
+
+try compressor.finish();
+```

--- a/build.zig
+++ b/build.zig
@@ -60,7 +60,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    mod.addImport("zlib", zlib_translate.createModule());
+    mod.addImport("zlib_h", zlib_translate.createModule());
 
     const test_mod = b.addTest(.{
         .root_module = mod,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zlib,
     .version = "1.3.1",
     .fingerprint = 0x73887d3a953b9465,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{
         .zlib = .{
             .url = "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
@@ -14,5 +14,6 @@
         "README.md",
         "build.zig",
         "build.zig.zon",
+        "src",
     },
 }

--- a/src/Deflate.zig
+++ b/src/Deflate.zig
@@ -200,7 +200,7 @@ fn zLibError(ret: c_int) !void {
 
 test "fuzz compress zlib deflate -> zig stdlib inflate" {
     const FlateFuzz = struct {
-        ob: []u8,
+        outbuf: []u8,
         infbuf: []u8,
 
         const Input = struct {
@@ -219,7 +219,7 @@ test "fuzz compress zlib deflate -> zig stdlib inflate" {
             if (inbuf.len < 10 or inbuf.len > 4097) return;
             const input = Input.fromBytes(inbuf);
 
-            var ow = std.Io.Writer.fixed(ctx.ob);
+            var ow = std.Io.Writer.fixed(ctx.outbuf);
             var deflate: Self = try .init(.{
                 .allocator = std.testing.allocator,
                 .writer = &ow,
@@ -260,11 +260,11 @@ test "fuzz compress zlib deflate -> zig stdlib inflate" {
         }
     };
     var ctx: FlateFuzz = .{
-        .ob = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 20)),
+        .outbuf = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 20)),
         .infbuf = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 20)),
     };
     defer {
-        std.testing.allocator.free(ctx.ob);
+        std.testing.allocator.free(ctx.outbuf);
         std.testing.allocator.free(ctx.infbuf);
     }
     {

--- a/src/Deflate.zig
+++ b/src/Deflate.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const Io = std.Io;
 const Self = @This();
-const Deflater = Self;
 const Container = std.compress.flate.Container;
 const Decompress = std.compress.flate.Decompress;
 const zlib = @import("zlib_h");
@@ -221,15 +220,15 @@ test "fuzz compress zlib deflate -> zig stdlib inflate" {
             const input = Input.fromBytes(inbuf);
 
             var ow = std.Io.Writer.fixed(ctx.ob);
-            var deflater: Deflater = try .init(.{
+            var deflate: Self = try .init(.{
                 .allocator = std.testing.allocator,
                 .writer = &ow,
                 .container = input.container,
             });
-            defer deflater.deinit();
+            defer deflate.deinit();
 
-            try deflater.writer.writeAll(input.bytes);
-            try deflater.finish();
+            try deflate.writer.writeAll(input.bytes);
+            try deflate.finish();
 
             var infr = std.Io.Reader.fixed(ow.buffered());
             var inf = Decompress.init(

--- a/src/Deflate.zig
+++ b/src/Deflate.zig
@@ -1,0 +1,280 @@
+const std = @import("std");
+const Io = std.Io;
+const Self = @This();
+const Deflater = Self;
+pub const Container = std.compress.flate.Container;
+const Decompress = std.compress.flate.Decompress;
+
+// needs to link:
+// https://github.com/allyourcodebase/zlib
+const zlib = @import("zlib");
+
+const CHUNKSIZE = 16 * 1024;
+
+arena: *std.heap.ArenaAllocator,
+zstream_initialized: bool,
+container: Container,
+level: u4,
+zstream: zlib.z_stream,
+outbuf: []u8,
+underlying_writer: *std.io.Writer,
+writer: std.io.Writer,
+
+pub const Options = struct {
+    allocator: std.mem.Allocator,
+    level: u4 = 9,
+    writer: *std.io.Writer,
+    container: Container,
+};
+
+pub fn init(opt: Self.Options) !Self {
+    const arena = try opt.allocator.create(std.heap.ArenaAllocator);
+    arena.* = .init(opt.allocator);
+    return .{
+        .arena = arena,
+        .zstream_initialized = false,
+        .container = opt.container,
+        .level = opt.level,
+        .zstream = .{
+            .zalloc = &zalloc,
+            .zfree = &zfree,
+            .@"opaque" = null,
+            .next_in = zlib.Z_NULL,
+            .avail_in = 0,
+            .next_out = zlib.Z_NULL,
+            .avail_out = 0,
+            .data_type = zlib.Z_BINARY,
+        },
+        .outbuf = try arena.allocator().alloc(u8, CHUNKSIZE),
+        .writer = .{
+            .buffer = try arena.allocator().alloc(u8, CHUNKSIZE),
+            .vtable = &.{
+                .drain = drain,
+                .flush = flush,
+                .sendFile = sendFile,
+            },
+        },
+        .underlying_writer = opt.writer,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    const alloc = self.arena.child_allocator;
+    self.arena.deinit();
+    alloc.destroy(self.arena);
+}
+
+fn zalloc(ctx: ?*anyopaque, count: c_uint, size: c_uint) callconv(.c) ?*anyopaque {
+    const self: *Self = @ptrCast(@alignCast(ctx.?));
+    return (self.arena.allocator().alloc(u1, count * size) catch {
+        return null;
+    }).ptr;
+}
+
+fn zfree(_: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {}
+
+inline fn zStreamInit(self: *@This()) !void {
+    if (!self.zstream_initialized) {
+        self.zstream.@"opaque" = self;
+        try zLibError(zlib.deflateInit2(
+            &self.zstream,
+            self.level,
+            zlib.Z_DEFLATED,
+            @as(c_int, switch (self.container) {
+                .raw => -1 * zlib.MAX_WBITS,
+                .gzip => 16 + zlib.MAX_WBITS,
+                .zlib => zlib.MAX_WBITS,
+            }),
+            zlib.MAX_MEM_LEVEL,
+            zlib.Z_DEFAULT_STRATEGY,
+        ));
+        self.zstream_initialized = true;
+    }
+}
+
+fn drain(wr: *Io.Writer, blobs: []const []const u8, splat: usize) error{WriteFailed}!usize {
+    const self: *Self = @fieldParentPtr("writer", wr);
+    self.zStreamInit() catch |err| {
+        std.log.err("zstream:\n{any}", .{self.zstream});
+        std.log.err("zlib error: {}\n", .{err});
+        return error.WriteFailed;
+    };
+
+    try self.zdrain(wr.buffered(), zlib.Z_NO_FLUSH);
+    wr.end = 0;
+
+    var count: usize = 0;
+    for (blobs, 1..) |blob, i| {
+        var splat_i: usize = 0;
+        while ((i != blobs.len and splat_i == 0) or (i == blobs.len and splat_i < splat)) : (splat_i += 1) {
+            try self.zdrain(blob, zlib.Z_NO_FLUSH);
+            count += blob.len;
+        }
+    }
+    return count;
+}
+
+fn zdrain(self: *Self, blob: []const u8, flush_flag: c_int) !void {
+    self.zstream.next_in = @constCast(blob.ptr);
+    self.zstream.avail_in = @intCast(blob.len);
+
+    self.zstream.avail_out = 0;
+    while (self.zstream.avail_out == 0) {
+        self.zstream.next_out = self.outbuf.ptr;
+        self.zstream.avail_out = @intCast(self.outbuf.len);
+
+        // std.log.warn("zdrain input: {} {x}", .{ self.zstream.avail_in, self.zstream.next_in[0..self.zstream.avail_in] });
+        zLibError(zlib.deflate(&self.zstream, flush_flag)) catch |err| {
+            if (flush_flag == zlib.Z_FINISH and err == error.Z_STREAM_END) {
+                const have = self.outbuf.len - self.zstream.avail_out;
+                try self.underlying_writer.writeAll(self.outbuf[0..have]);
+                break;
+            }
+            std.log.err("zstream:\n{any}", .{self.zstream});
+            std.log.err("zlib error: {}\n", .{err});
+            return error.WriteFailed;
+        };
+        const have = self.outbuf.len - self.zstream.avail_out;
+        try self.underlying_writer.writeAll(self.outbuf[0..have]);
+    }
+    std.debug.assert(self.zstream.avail_in == 0);
+}
+
+fn sendFile(
+    wr: *Io.Writer,
+    file_reader: *std.fs.File.Reader,
+    limit: Io.Limit,
+) Io.Writer.FileError!usize {
+    const self: *Self = @fieldParentPtr("writer", wr);
+    self.zStreamInit() catch |err| {
+        std.log.err("zstream:\n{any}", .{self.zstream});
+        std.log.err("zlib error: {}\n", .{err});
+        return error.WriteFailed;
+    };
+
+    try self.zdrain(wr.buffered(), zlib.Z_NO_FLUSH);
+    wr.end = 0;
+    var transferred: usize = 0;
+    while (limit == .unlimited or transferred < @intFromEnum(limit)) {
+        const to_read = @min(wr.buffer.len, @intFromEnum(limit) - transferred);
+        const just_read = try file_reader.readStreaming(wr.buffer[0..to_read]);
+        transferred += just_read;
+        try self.zdrain(wr.buffer[0..just_read], zlib.Z_NO_FLUSH);
+        if (file_reader.atEnd()) break;
+    }
+    return transferred;
+}
+
+fn flush(wr: *Io.Writer) Io.Writer.Error!void {
+    const self: *Self = @fieldParentPtr("writer", wr);
+    self.zStreamInit() catch |err| {
+        std.log.err("zstream:\n{any}", .{self.zstream});
+        std.log.err("zlib error: {}\n", .{err});
+        return error.WriteFailed;
+    };
+
+    const blob = wr.buffered();
+    try self.zdrain(blob, zlib.Z_FULL_FLUSH);
+    wr.end = 0;
+}
+
+pub fn finish(self: *Self) !void {
+    try self.zStreamInit();
+
+    const blob = self.writer.buffered();
+    try self.zdrain(blob, zlib.Z_FINISH);
+    self.writer.end = 0;
+    try zLibError(zlib.deflateEnd(&self.zstream));
+}
+
+fn zLibError(ret: c_int) !void {
+    return switch (ret) {
+        zlib.Z_OK => {},
+        zlib.Z_BUF_ERROR => error.Z_BUF_ERROR,
+        zlib.Z_DATA_ERROR => error.Z_DATA_ERROR,
+        zlib.Z_ERRNO => error.Z_ERRNO,
+        zlib.Z_MEM_ERROR => error.Z_MEM_ERROR,
+        zlib.Z_NEED_DICT => error.Z_NEED_DICT,
+        zlib.Z_STREAM_END => error.Z_STREAM_END,
+        zlib.Z_STREAM_ERROR => error.Z_STREAM_ERROR,
+        zlib.Z_VERSION_ERROR => error.Z_VERSION_ERROR,
+        else => error.ZLibUnknown,
+    };
+}
+
+test "fuzz compress zlib deflate -> zig stdlib inflate" {
+    const FlateFuzz = struct {
+        ob: []u8,
+        infbuf: []u8,
+
+        const Input = struct {
+            container: Container,
+            bytes: []const u8,
+            fn fromBytes(inbuf: []const u8) Input {
+                std.debug.assert(inbuf.len > 0);
+                return .{
+                    .container = @enumFromInt(inbuf[0] % std.meta.fields(Container).len),
+                    .bytes = inbuf[1..],
+                };
+            }
+        };
+
+        fn testOne(ctx: *@This(), inbuf: []const u8) anyerror!void {
+            if (inbuf.len < 10 or inbuf.len > 4097) return;
+            const input = Input.fromBytes(inbuf);
+
+            var ow = std.Io.Writer.fixed(ctx.ob);
+            var deflater: Deflater = try .init(.{
+                .allocator = std.testing.allocator,
+                .writer = &ow,
+                .container = input.container,
+            });
+            defer deflater.deinit();
+
+            try deflater.writer.writeAll(input.bytes);
+            try deflater.finish();
+
+            var infr = std.Io.Reader.fixed(ow.buffered());
+            var inf = Decompress.init(
+                &infr,
+                input.container,
+                ctx.infbuf,
+            );
+            const output = try inf.reader.take(input.bytes.len);
+
+            std.testing.expect(std.mem.eql(u8, input.bytes, output)) catch |err| {
+                for (input.bytes, 0..) |_, it| {
+                    if (output.len < it or input.bytes[it] != output[it]) {
+                        std.log.err("expected (@offset {}): 0x{x}", .{ it, input.bytes[it..] });
+                        std.log.err("actual   (@offset {}): 0x{x}", .{ it, output[it..] });
+                        break;
+                    }
+                }
+                std.log.err("compressed: 0x{x}", .{ow.buffered()});
+                std.log.err("container:  {} in_len: {} out_len: {}", .{
+                    input.container,
+                    input.bytes.len,
+                    output.len,
+                });
+                return err;
+            };
+        }
+    };
+    var ctx: FlateFuzz = .{
+        .ob = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 20)),
+        .infbuf = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 20)),
+    };
+    defer {
+        std.testing.allocator.free(ctx.ob);
+        std.testing.allocator.free(ctx.infbuf);
+    }
+    {
+        var comp_test_buffer: [4097]u8 = @splat(0);
+        inline for (comptime std.meta.fields(Container)) |cf| {
+            std.log.warn("test compressing container: {s}", .{cf.name});
+            comp_test_buffer[0] = cf.value;
+            try ctx.testOne(&comp_test_buffer);
+        }
+    }
+    try std.testing.fuzz(&ctx, FlateFuzz.testOne, .{});
+}

--- a/src/Deflate.zig
+++ b/src/Deflate.zig
@@ -196,7 +196,7 @@ fn zLibError(ret: c_int) !void {
 test "fuzz compress zlib deflate -> zig stdlib inflate" {
     const FlateFuzz = struct {
         outbuf: []u8,
-        infbuf: []u8,
+        inbuf: []u8,
 
         const Input = struct {
             container: Container,
@@ -213,7 +213,7 @@ test "fuzz compress zlib deflate -> zig stdlib inflate" {
         };
 
         fn testOne(ctx: *@This(), inbuf: []const u8) anyerror!void {
-            if (inbuf.len < 10 or inbuf.len > 4097) return;
+            if (inbuf.len < 10 or inbuf.len > ctx.inbuf.len) return;
             const input = Input.fromBytes(inbuf);
 
             var ow = std.Io.Writer.fixed(ctx.outbuf);
@@ -232,7 +232,7 @@ test "fuzz compress zlib deflate -> zig stdlib inflate" {
             var inf = Decompress.init(
                 &infr,
                 input.container,
-                ctx.infbuf,
+                ctx.inbuf,
             );
             try inf.reader.fillMore();
             const output = inf.reader.buffered();
@@ -259,11 +259,11 @@ test "fuzz compress zlib deflate -> zig stdlib inflate" {
     };
     var ctx: FlateFuzz = .{
         .outbuf = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 30)),
-        .infbuf = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 30)),
+        .inbuf = try std.testing.allocator.alloc(u8, std.math.pow(usize, 2, 30)),
     };
     defer {
         std.testing.allocator.free(ctx.outbuf);
-        std.testing.allocator.free(ctx.infbuf);
+        std.testing.allocator.free(ctx.inbuf);
     }
     {
         var comp_test_buffer: [4097]u8 = @splat(0);

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub const Deflate = @import("Deflate.zig");
+
+comptime {
+    std.testing.refAllDecls(Deflate);
+}


### PR DESCRIPTION
Hi Allyourcodebase maintainers,

Since we're missing Deflate in the standard library, i have added a `std.Io.Writer` interface to zlib,
including a (fuzz) test against the standard library Inflate code :-D

